### PR TITLE
Fixes image height

### DIFF
--- a/style.css
+++ b/style.css
@@ -55,6 +55,10 @@ a {
 	margin-top: 20px;
 }
 
+.wp-block-image img {
+	height: auto;
+}
+
 /**********************
  Header
  ***********************/


### PR DESCRIPTION
The height of some images at the blog was distorted after a WordPress update. CSS auto height is now applied to all images.

@k01255322 CSS is already live for you to test, please review :+1: 

refs #10